### PR TITLE
fix: Remove default value "." from INPUT_TSC_FLAGS (fix #39)

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -27,7 +27,7 @@ else
   echo "::group::📝 Running tsc with reviewdog 🐶 ..."
 
   # shellcheck disable=SC2086
-  "$(npm bin)"/tsc ${INPUT_TSC_FLAGS:-"."} \
+  "$(npm bin)"/tsc ${INPUT_TSC_FLAGS} \
     | reviewdog -f=tsc \
       -name="${INPUT_TOOL_NAME}" \
       -reporter="${INPUT_REPORTER:-github-pr-review}" \


### PR DESCRIPTION
### Summary
This PR fixes a bug where the value of `INPUT_TSC_FLAGS` defaults to `"."`.

### Details
To run `tsc` against the current directory, `tsc` should be run without any file names. [tsc CLI options](https://www.typescriptlang.org/docs/handbook/compiler-options.html#using-the-cli)
Currently with the default flag set to `"."`, `tsc .` is invoked, which would lead to `tsc` trying to find a file named `.`.