### PR TITLE
Add new FAQ to README in case users cannot see results due to the default `filter_mode`

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,9 @@ jobs:
           workdir: submodule2
 ```
 
+### Why can't I see the results?
+Try looking into the `filter_mode` options explained [here](https://github.com/reviewdog/reviewdog#filter-mode). Typescript errors will sometimes appear in lines or files that weren't modified by the commit the workflow run is associated with, which instead get filtered with the default `added` option.
+
 ## Contributing
 
 Want to improve this action? Cool! :rocket: Please make sure to read the [Contribution Guidelines](CONTRIBUTING.md) prior submitting your work.

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ jobs:
 ```
 
 ### Why can't I see the results?
-Try looking into the `filter_mode` options explained [here](https://github.com/reviewdog/reviewdog#filter-mode). Typescript errors will sometimes appear in lines or files that weren't modified by the commit the workflow run is associated with, which instead get filtered with the default `added` option.
+Try looking into the `filter_mode` options explained [here](https://github.com/reviewdog/reviewdog#filter-mode). TypeScript errors will sometimes appear in lines or files that weren't modified by the commit the workflow run is associated with, which instead get filtered with the default `added` option.
 
 ## Contributing
 


### PR DESCRIPTION
### Summary
This PR adds a new FAQ for users having trouble with seeing the results.
closes #39 

### Details
The newly added FAQ looks like below.
```markdown
### Why can't I see the results?
Try looking into the `filter_mode` options explained [here](https://github.com/reviewdog/reviewdog#filter-mode). TypeScript errors will sometimes appear in lines or files that weren't modified by the commit the workflow run is associated with, which instead get filtered with the default `added` option.
```