### PR TITLE
Fix action not working on npm v9

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # reviewdog-action-tsc
 
 ![Maintained](https://img.shields.io/badge/maintained-yes-brightgreen) 
-[![Test](https://github.com/EPMatt/reviewdog-action-tsc/workflows/Tests/badge.svg)](https://github.com/EPMatt/reviewdog-action-tsc/actions?query=workflow%3ATest)
-[![Code Quality](https://github.com/EPMatt/reviewdog-action-tsc/workflows/Code%20Quality/badge.svg)](https://github.com/EPMatt/reviewdog-action-tsc/actions?query=workflow%3Areviewdog)
-[![Deps auto update](https://github.com/EPMatt/reviewdog-action-tsc/workflows/Deps%20auto%20update/badge.svg)](https://github.com/EPMatt/reviewdog-action-tsc/actions?query=workflow%3Adepup)
-[![Release](https://github.com/EPMatt/reviewdog-action-tsc/workflows/Release/badge.svg)](https://github.com/EPMatt/reviewdog-action-tsc/actions?query=workflow%3Arelease)
+[![Tests](https://github.com/EPMatt/reviewdog-action-tsc/actions/workflows/test.yml/badge.svg)](https://github.com/EPMatt/reviewdog-action-tsc/actions/workflows/test.yml)
+[![Code Quality](https://github.com/EPMatt/reviewdog-action-tsc/actions/workflows/reviewdog.yml/badge.svg)](https://github.com/EPMatt/reviewdog-action-tsc/actions/workflows/reviewdog.yml)
+[![Deps auto update](https://github.com/EPMatt/reviewdog-action-tsc/actions/workflows/depup.yml/badge.svg)](https://github.com/EPMatt/reviewdog-action-tsc/actions/workflows/depup.yml)
+[![Release](https://github.com/EPMatt/reviewdog-action-tsc/actions/workflows/release.yml/badge.svg)](https://github.com/EPMatt/reviewdog-action-tsc/actions/workflows/release.yml)
 [![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/EPMatt/reviewdog-action-tsc?logo=github&sort=semver)](https://github.com/EPMatt/reviewdog-action-tsc/releases)
 [![action-bumpr supported](https://img.shields.io/badge/bumpr-supported-ff69b4?logo=github&link=https://github.com/haya14busa/action-bumpr)](https://github.com/haya14busa/action-bumpr)
 

--- a/script.sh
+++ b/script.sh
@@ -4,23 +4,23 @@ cd "${GITHUB_WORKSPACE}/${INPUT_WORKDIR}" || exit 1
 
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
-if [ ! -f "$(npm bin)"/tsc ]; then
+if [ ! -f "$(npm root)"/.bin/tsc ]; then
   echo "::group::🔄 Running npm install to install tsc ..."
   npm install
   echo "::endgroup::"
 fi
 
-if [ ! -f "$(npm bin)"/tsc ]; then
+if [ ! -f "$(npm root)"/.bin/tsc ]; then
   echo "❌ Unable to locate or install tsc. Did you provide a workdir which contains a valid package.json?"
   exit 1
 else
 
-  echo ℹ️ tsc version: "$("$(npm bin)"/tsc --version)"
+  echo ℹ️ tsc version: "$("$(npm root)"/.bin/tsc --version)"
 
   echo "::group::📝 Running tsc with reviewdog 🐶 ..."
 
   # shellcheck disable=SC2086
-  "$(npm bin)"/tsc ${INPUT_TSC_FLAGS} \
+  "$(npm root)"/.bin/tsc ${INPUT_TSC_FLAGS} \
     | reviewdog -f=tsc \
       -name="${INPUT_TOOL_NAME}" \
       -reporter="${INPUT_REPORTER}" \

--- a/script.sh
+++ b/script.sh
@@ -20,8 +20,8 @@ else
   echo "::group::📝 Running tsc with reviewdog 🐶 ..."
 
   # shellcheck disable=SC2086
-  "$(npm root)"/.bin/tsc ${INPUT_TSC_FLAGS} \
-    | reviewdog -f=tsc \
+  "$(npm root)"/.bin/tsc ${INPUT_TSC_FLAGS} |
+    reviewdog -f=tsc \
       -name="${INPUT_TOOL_NAME}" \
       -reporter="${INPUT_REPORTER}" \
       -filter-mode="${INPUT_FILTER_MODE}" \


### PR DESCRIPTION
Fixes #157. The issue is due to the removal of `npm bin` starting from `npm` version 9.
The same problem affected my other reviewdog-based action: https://github.com/EPMatt/reviewdog-action-prettier/issues/34

The fix is identical to https://github.com/EPMatt/reviewdog-action-prettier/pull/36. 