### PR TITLE
feat: add fail_level and deduplicate fail_on_error

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,18 @@ inputs:
       Default is `added`.
     default: 'added'
     required: false
+  fail_level:
+    description: |
+      If set to `none`, always use exit code 0 for reviewdog. Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
+      Possible values: [none,any,info,warning,error]
+      Default is `none`.
+    default: 'none'
   fail_on_error:
     description: |
+      Deprecated, use `fail_level` instead.
       Exit code for reviewdog when errors are found [true,false].
       Default is `false`.
+    deprecationMessage: Deprecated, use `fail_level` instead.
     default: 'false'
     required: false
   reviewdog_flags:

--- a/action.yml
+++ b/action.yml
@@ -33,10 +33,18 @@ inputs:
       Default is `added`.
     default: 'added'
     required: false
+  fail_level:
+    description: |
+      If set to `none`, always use exit code 0 for reviewdog. Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
+      Possible values: [none,any,info,warning,error]
+      Default is `none`.
+    default: 'none'
   fail_on_error:
     description: |
+      Deprecated, use `fail_level` instead.
       Exit code for reviewdog when errors are found [true,false].
       Default is `false`.
+    deprecationMessage: Deprecated, use `fail_level` instead.
     default: 'false'
     required: false
   reviewdog_flags:
@@ -70,6 +78,7 @@ runs:
         INPUT_LEVEL: ${{ inputs.level }}
         INPUT_REPORTER: ${{ inputs.reporter }}
         INPUT_FILTER_MODE: ${{ inputs.filter_mode }}
+        INPUT_FAIL_LEVEL: ${{ inputs.fail_level }}
         INPUT_FAIL_ON_ERROR: ${{ inputs.fail_on_error }}
         INPUT_REVIEWDOG_FLAGS: ${{ inputs.reviewdog_flags }}
         INPUT_TOOL_NAME: ${{ inputs.tool_name }}

--- a/script.sh
+++ b/script.sh
@@ -25,6 +25,7 @@ else
       -name="${INPUT_TOOL_NAME}" \
       -reporter="${INPUT_REPORTER}" \
       -filter-mode="${INPUT_FILTER_MODE}" \
+      -fail-level=${INPUT_FAIL_LEVEL} \
       -fail-on-error="${INPUT_FAIL_ON_ERROR}" \
       -level="${INPUT_LEVEL}" \
       ${INPUT_REVIEWDOG_FLAGS}


### PR DESCRIPTION
Same as https://github.com/reviewdog/action-eslint/pull/224

> In [reviewdog/reviewdog#1854](https://github.com/reviewdog/reviewdog/pull/1854), we add `-fail-level` to reviewdog and deduplicate `-fail-on-error`. I apply it to this actions.