### PR TITLE
Pin `reviewdog/action-setup`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -59,7 +59,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: reviewdog/action-setup@v1
+    - uses: reviewdog/action-setup@e04ffabe3898a0af8d0fb1af00c188831c4b5893 # v1.3.2
       with:
         reviewdog_version: v0.17.4
     - run: $GITHUB_ACTION_PATH/script.sh


### PR DESCRIPTION
Hi there!

While auditing third-party GitHub actions we use to assess the potential impact of the recent round of supply chain attacks, I noticed that this action has a `@v1` dependency on the compromised `reviewdog/action-setup`.

Given 
- reviewdog's recent security incident (https://www.wiz.io/blog/new-github-action-supply-chain-attack-reviewdog-action-setup, https://github.com/reviewdog/reviewdog/issues/2079)
- GitHub's general recommendations (https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)
- changes in reviewdog's repository templates to do the same: https://github.com/reviewdog/action-composite-template/blob/e9705ce0ba259ff74f1795f3b742375965be8b0f/action.yml#L46

it would be prudent to pin `reviewdog/action-setup` to a specific SHA.

